### PR TITLE
Fixing function signatures

### DIFF
--- a/src/Diff.jl
+++ b/src/Diff.jl
@@ -122,8 +122,8 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
         end
         # check them against matching courses in c2 looking for different prereqs
         for course in all_courses_not_in_c2
-            c1 = course_from_name(curriculum1, course)
-            c2 = course_from_name(curriculum2, course)
+            c1 = course_from_name(course, curriculum1)
+            c2 = course_from_name(course, curriculum2)
             # find their prerequisites
             prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(c1, curriculum1)))
 
@@ -152,8 +152,8 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
         end
         # check them against matching courses in c2 looking for different prereqs
         for course in all_courses_not_in_c1
-            c1 = course_from_name(curriculum1, course)
-            c2 = course_from_name(curriculum2, course)
+            c1 = course_from_name(course, curriculum1)
+            c2 = course_from_name(course, curriculum2)
             # find their prerequisites
             isnothing(c1) ? prereqs_in_curr1 = Set() :
             prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(c1, curriculum1)))
@@ -200,8 +200,8 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
             for course_name in not_in_c2_unbl_field
                 explanations_blockingfactor["not in c2 ufield"][course_name] = Dict()
                 # find course to match name in curriculum1 and curriculum2
-                course_in_curr1 = course_from_name(curriculum1, course_name)
-                course_in_curr2 = course_from_name(curriculum2, course_name)
+                course_in_curr1 = course_from_name(course_name, curriculum1)
+                course_in_curr2 = course_from_name(course_name, curriculum2)
                 # and find c1 prereqs
                 prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(course_in_curr1, curriculum1)))
                 if (!isnothing(course_in_curr2))
@@ -245,8 +245,8 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
             for course_name in not_in_c1_unbl_field
                 explanations_blockingfactor["not in c1 ufield"][course_name] = Dict()
                 # find course to match name in curriculum1 and curriculum2
-                course_in_curr1 = course_from_name(curriculum1, course_name)
-                course_in_curr2 = course_from_name(curriculum2, course_name)
+                course_in_curr1 = course_from_name(course_name, curriculum1)
+                course_in_curr2 = course_from_name(course_name, curriculum2)
                 # find prereqs in c2
                 prereqs_in_curr2 = Set(courses_to_course_names(get_course_prereqs(course_in_curr2, curriculum2)))
                 if (!isnothing(course_in_curr1))
@@ -308,8 +308,8 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
         for course in all_courses_in_paths
             explanations_delayfactor["courses involved"][course] = Dict()
             # find course to match name in curriculum1 and curriculum2
-            course_in_curr1 = course_from_name(curriculum1, course)
-            course_in_curr2 = course_from_name(curriculum2, course)
+            course_in_curr1 = course_from_name(course, curriculum1)
+            course_in_curr2 = course_from_name(course, curriculum2)
             # find their prerequisites
             isnothing(course_in_curr1) ? prereqs_in_curr1 = Set() :
             prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(course_in_curr1, curriculum1)))
@@ -488,7 +488,7 @@ function curricular_diff(curriculum1::Curriculum, curriculum2::Curriculum, verbo
                     # try one more time with the course_find method
                     (found, course1_name, course2_name) = course_find(course.name, redundant_course_names, curriculum2)
                     if (found)
-                        results = course_diff(course, course_from_name(curriculum2, course2_name), curriculum1, curriculum2, verbose)
+                        results = course_diff(course, course_from_name(course2_name, curriculum2), curriculum1, curriculum2, verbose)
                         contribution = results["contribution to curriculum differences"]
                         for (key, value) in runningTally
                             runningTally[key] += contribution[key]

--- a/src/Diff.jl
+++ b/src/Diff.jl
@@ -13,7 +13,7 @@ function course_diff_for_unmatched_course(course::Course, curriculum::Curriculum
     results["contribution to curriculum differences"] = contribution
     results["complexity"] = course.metrics["complexity"]
     results["centrality"] = course.metrics["centrality"]
-    results["prereqs"] = courses_to_course_names(get_course_prereqs(curriculum, course))
+    results["prereqs"] = courses_to_course_names(get_course_prereqs(course, curriculum))
     results["blocking factor"] = course.metrics["blocking factor"]
     results["delay factor"] = course.metrics["delay factor"]
     results
@@ -125,10 +125,10 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
             c1 = course_from_name(curriculum1, course)
             c2 = course_from_name(curriculum2, course)
             # find their prerequisites
-            prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(curriculum1, c1)))
+            prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(c1, curriculum1)))
 
             isnothing(c2) ? prereqs_in_curr2 = Set() :
-            prereqs_in_curr2 = Set(courses_to_course_names(get_course_prereqs(curriculum2, c2)))
+            prereqs_in_curr2 = Set(courses_to_course_names(get_course_prereqs(c2, curriculum2)))
             # compare the prerequisites
             # lost prereqs are those that from c1 to c2 got dropped
             # gained prerqs are those that from c1 to c2 got added
@@ -156,8 +156,8 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
             c2 = course_from_name(curriculum2, course)
             # find their prerequisites
             isnothing(c1) ? prereqs_in_curr1 = Set() :
-            prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(curriculum1, c1)))
-            prereqs_in_curr2 = Set(courses_to_course_names(get_course_prereqs(curriculum2, c2)))
+            prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(c1, curriculum1)))
+            prereqs_in_curr2 = Set(courses_to_course_names(get_course_prereqs(c2, curriculum2)))
             # compare the prerequisites
             # lost prereqs are those that from c1 to c2 got dropped
             # gained prerqs are those that from c1 to c2 got added
@@ -203,10 +203,10 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
                 course_in_curr1 = course_from_name(curriculum1, course_name)
                 course_in_curr2 = course_from_name(curriculum2, course_name)
                 # and find c1 prereqs
-                prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(curriculum1, course_in_curr1)))
+                prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(course_in_curr1, curriculum1)))
                 if (!isnothing(course_in_curr2))
                     # find their prerequisites
-                    prereqs_in_curr2 = Set(courses_to_course_names(get_course_prereqs(curriculum2, course_in_curr2)))
+                    prereqs_in_curr2 = Set(courses_to_course_names(get_course_prereqs(course_in_curr2, curriculum2)))
                     # compare the prerequisites
                     # lost prereqs are those that from c1 to c2 got dropped
                     # gained prerqs are those that from c1 to c2 got added
@@ -216,7 +216,7 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
                     explanations_blockingfactor["not in c2 ufield"][course_name]["gained prereqs"] = collect(gained_prereqs)
                 else
                     # if there's no match in curriculum 2, then just say all the prereqs were lost and none were gained
-                    explanations_blockingfactor["not in c2 ufield"][course_name]["lost prereqs"] = courses_to_course_names(get_course_prereqs(curriculum1, course_in_curr1))
+                    explanations_blockingfactor["not in c2 ufield"][course_name]["lost prereqs"] = courses_to_course_names(get_course_prereqs(course_in_curr1, curriculum1))
                     explanations_blockingfactor["not in c2 ufield"][course_name]["gained prereqs"] = []
                 end
                 # check if the prereqs haven't changed. If they haven't changed, we need to find which of their prereqs did
@@ -248,10 +248,10 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
                 course_in_curr1 = course_from_name(curriculum1, course_name)
                 course_in_curr2 = course_from_name(curriculum2, course_name)
                 # find prereqs in c2
-                prereqs_in_curr2 = Set(courses_to_course_names(get_course_prereqs(curriculum2, course_in_curr2)))
+                prereqs_in_curr2 = Set(courses_to_course_names(get_course_prereqs(course_in_curr2, curriculum2)))
                 if (!isnothing(course_in_curr1))
                     # find their prerequisites
-                    prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(curriculum1, course_in_curr1)))
+                    prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(course_in_curr1, curriculum1)))
 
                     # compare the prerequisites
                     lost_prereqs = setdiff(prereqs_in_curr1, prereqs_in_curr2)
@@ -262,7 +262,7 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
                 else
                     # if there's no match in curriculum 2, then just say that all the prereqs have been gained and none were lost
                     explanations_blockingfactor["not in c1 ufield"][course_name]["lost prereqs"] = []
-                    explanations_blockingfactor["not in c1 ufield"][course_name]["gained prereqs"] = courses_to_course_names(get_course_prereqs(curriculum2, course_in_curr2))
+                    explanations_blockingfactor["not in c1 ufield"][course_name]["gained prereqs"] = courses_to_course_names(get_course_prereqs(course_in_curr2, curriculum2))
                 end
                 # check if the prereqs haven't changed. If they haven't changed, we need to find which of their prereqs did
                 if (length(explanations_blockingfactor["not in c1 ufield"][course_name]["lost prereqs"]) == 0 &&
@@ -312,10 +312,10 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
             course_in_curr2 = course_from_name(curriculum2, course)
             # find their prerequisites
             isnothing(course_in_curr1) ? prereqs_in_curr1 = Set() :
-            prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(curriculum1, course_in_curr1)))
+            prereqs_in_curr1 = Set(courses_to_course_names(get_course_prereqs(course_in_curr1, curriculum1)))
 
             isnothing(course_in_curr2) ? prereqs_in_curr2 = Set() :
-            prereqs_in_curr2 = Set(courses_to_course_names(get_course_prereqs(curriculum2, course_in_curr2)))
+            prereqs_in_curr2 = Set(courses_to_course_names(get_course_prereqs(course_in_curr2, curriculum2)))
             # compare the prerequisites
             # lost prereqs are those that from c1 to c2 got dropped
             # gained prerqs are those that from c1 to c2 got added
@@ -328,8 +328,8 @@ function course_diff(course1::Course, course2::Course, curriculum1::Curriculum, 
     end
     # requisites
     # collate all the prerequisite names from course 1
-    course1_prereqs = Set(courses_to_course_names(get_course_prereqs(curriculum1, course1)))
-    course2_prereqs = Set(courses_to_course_names(get_course_prereqs(curriculum2, course2)))
+    course1_prereqs = Set(courses_to_course_names(get_course_prereqs(course1, curriculum1)))
+    course2_prereqs = Set(courses_to_course_names(get_course_prereqs(course2, curriculum2)))
 
     explanations_prereqs = Dict()
     lost_prereqs = setdiff(course1_prereqs, course2_prereqs)

--- a/src/Diff.jl
+++ b/src/Diff.jl
@@ -1,7 +1,4 @@
 using CurricularAnalytics, Crayons, Crayons.Box, CSV
-#include("./HelperFns.jl")
-
-# all, centrality, complexity, blocking, delay, prereq
 
 function course_diff_for_unmatched_course(course::Course, curriculum::Curriculum, c1::Bool)
     results = Dict()

--- a/src/HelperFns.jl
+++ b/src/HelperFns.jl
@@ -58,7 +58,7 @@ function get_course_prereqs(course::Course, curriculum::Curriculum)
     course_prereqs
 end
 
-function course_from_name(curriculum::Curriculum, course_name::AbstractString)
+function course_from_name(course_name::AbstractString, curriculum::Curriculum)
     for c in curriculum.courses
         if c.name == course_name
             return c

--- a/src/HelperFns.jl
+++ b/src/HelperFns.jl
@@ -46,7 +46,7 @@ function prereq_print(prereqs::Set{AbstractString})
     string
 end
 
-function get_course_prereqs(curriculum::Curriculum, course::Course)
+function get_course_prereqs(course::Course, curriculum::Curriculum)
     # get all the prereqs
     course_prereqs = Vector{Course}()
     for (key, value) in course.requisites

--- a/src/Whatif.jl
+++ b/src/Whatif.jl
@@ -12,7 +12,7 @@ I remove a prereq?
 @enum Edit_Type add del
 
 # What if I add a course?
-function add_course(curr::Curriculum, course_name::AbstractString, credit_hours::Real, prereqs::Dict, dependencies::Dict)
+function add_course(course_name::AbstractString, curr::Curriculum, credit_hours::Real, prereqs::Dict, dependencies::Dict)
     ## create the course in the curricular analytics sense
     new_course = Course(course_name, credit_hours)
     modded_curric = deepcopy(curr)
@@ -43,7 +43,7 @@ function add_course(curr::Curriculum, course_name::AbstractString, credit_hours:
 end
 
 # What if I remove a course?
-function remove_course(curr::Curriculum, course_name::AbstractString)
+function remove_course(course_name::AbstractString, curr::Curriculum,)
     modded_curric = deepcopy(curr)
     course = course_from_name(course_name, modded_curric)
     if typeof(course) == Nothing
@@ -75,7 +75,7 @@ function remove_course(curr::Curriculum, course_name::AbstractString)
 end
 
 # What if I add a prereq to this course?
-function add_prereq(curr::Curriculum, course_name::AbstractString, added_prereq::AbstractString, reqtype::Requisite)
+function add_prereq(course_name::AbstractString, added_prereq::AbstractString, curr::Curriculum, reqtype::Requisite)
     modded_curric = deepcopy(curr)
 
     target_course = course_from_name(course_name, modded_curric)
@@ -91,7 +91,7 @@ function add_prereq(curr::Curriculum, course_name::AbstractString, added_prereq:
 end
 
 # What if I remove to_remove from course_name?
-function remove_prereq(curr::Curriculum, course_name::AbstractString, to_remove::AbstractString)
+function remove_prereq(course_name::AbstractString, to_remove::AbstractString, curr::Curriculum,)
     modded_curric = deepcopy(curr)
 
     course = course_from_name(course_name, modded_curric)

--- a/src/Whatif.jl
+++ b/src/Whatif.jl
@@ -19,7 +19,7 @@ function add_course(curr::Curriculum, course_name::AbstractString, credit_hours:
     ## hook it up to the curriculum
     # loop through the names of its prereqs and find them in modded_curric (so we don't alter the original)
     for (prereq, req_type) in prereqs
-        prereq_course = course_from_name(modded_curric, prereq)
+        prereq_course = course_from_name(prereq, modded_curric)
         if typeof(prereq_course) == Nothing
             throw(ArgumentError("I'm sorry, we couldn't find your requested prerequisite in the given curriculum. Are you sure its name matched the one in the file exactly?"))
         end
@@ -27,7 +27,7 @@ function add_course(curr::Curriculum, course_name::AbstractString, credit_hours:
     end
     # loop through the names of its dependencies and find them in modded_curric
     for (dep, type) in dependencies
-        dependent_course = course_from_name(modded_curric, dep)
+        dependent_course = course_from_name(dep, modded_curric)
         if typeof(dependent_course) == Nothing
             throw(ArgumentError("I'm sorry, we couldn't find your requested dependent course in the given curriculum. Are you sure its name matched the one in the file exactly?"))
         end
@@ -45,7 +45,7 @@ end
 # What if I remove a course?
 function remove_course(curr::Curriculum, course_name::AbstractString)
     modded_curric = deepcopy(curr)
-    course = course_from_name(modded_curric, course_name)
+    course = course_from_name(course_name, modded_curric)
     if typeof(course) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your requested course in the given curriculum. Are you sure its name matched the one in the file exactly?"))
     end
@@ -78,11 +78,11 @@ end
 function add_prereq(curr::Curriculum, course_name::AbstractString, added_prereq::AbstractString, reqtype::Requisite)
     modded_curric = deepcopy(curr)
 
-    target_course = course_from_name(modded_curric, course_name)
+    target_course = course_from_name(course_name, modded_curric)
     if typeof(target_course) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your requested course in the given curriculum. Are you sure its name matched the one in the file exactly?"))
     end
-    added_prq = course_from_name(modded_curric, added_prereq)
+    added_prq = course_from_name(course_name, modded_curric)
     if typeof(added_prq) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your requested prerequisite in the given curriculum. Are you sure its name matched the one in the file exactly?"))
     end
@@ -94,11 +94,11 @@ end
 function remove_prereq(curr::Curriculum, course_name::AbstractString, to_remove::AbstractString)
     modded_curric = deepcopy(curr)
 
-    course = course_from_name(modded_curric, course_name)
+    course = course_from_name(course_name, modded_curric)
     if typeof(course) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your requested course in the given curriculum. Are you sure its name matched the one in the file exactly?"))
     end
-    to_remove_course = course_from_name(modded_curric, to_remove)
+    to_remove_course = course_from_name(to_remove, modded_curric)
     if typeof(to_remove_course) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your requested prerequisite in the given curriculum. Are you sure its name matched the one in the file exactly?"))
     end

--- a/src/WhatifInstitutional.jl
+++ b/src/WhatifInstitutional.jl
@@ -1,10 +1,10 @@
 function delete_prerequisite_institutional(curriculum::Curriculum, target::AbstractString, prereq::AbstractString)
-    target_course = course_from_name(curriculum, target)
+    target_course = course_from_name(target, curriculum)
     # error check
     if typeof(target_course) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your target course in the given curriculum. Make sure you got the name exactly right."))
     end
-    prereq_course = course_from_name(curriculum, prereq)
+    prereq_course = course_from_name(prereq, curriculum)
     # error check
     if typeof(prereq_course) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your prerequisite course in the given curriculum. Make sure you got the name exactly right."))
@@ -29,12 +29,12 @@ function delete_prerequisite_institutional(curriculum::Curriculum, target::Abstr
 end
 
 function delete_prerequisite_institutional!(curriculum::Curriculum, target::AbstractString, prereq::AbstractString)
-    target_course = course_from_name(curriculum, target)
+    target_course = course_from_name(target, curriculum)
     # error check
     if typeof(target_course) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your target course in the given curriculum. Make sure you got the name exactly right."))
     end
-    prereq_course = course_from_name(curriculum, prereq)
+    prereq_course = course_from_name(prereq, curriculum)
     # error check
     if typeof(prereq_course) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your prerequisite course in the given curriculum. Make sure you got the name exactly right."))
@@ -57,7 +57,7 @@ function delete_prerequisite_institutional!(curriculum::Curriculum, target::Abst
 end
 
 function delete_course_institutional(curriculum::Curriculum, course_to_remove_name::AbstractString)
-    course_to_remove = course_from_name(curriculum, course_to_remove_name)
+    course_to_remove = course_from_name(course_to_remove_name, curriculum)
     if typeof(course_to_remove) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your target course in the given curriculum. Make sure you got the name exactly right."))
     end
@@ -98,7 +98,7 @@ function delete_course_institutional(curriculum::Curriculum, course_to_remove_na
 end
 
 function delete_course_institutional!(curriculum::Curriculum, course_to_remove_name::AbstractString)
-    course_to_remove = course_from_name(curriculum, course_to_remove_name)
+    course_to_remove = course_from_name(course_to_remove_name, curriculum)
     if typeof(course_to_remove) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your target course in the given curriculum. Make sure you got the name exactly right."))
     end
@@ -122,7 +122,7 @@ function add_course_institutional(curriculum::Curriculum, new_course_name::Abstr
     # get all the paths that depend on me
     ## first, get me
     #UCSD = read_csv("./targets/condensed.csv");
-    course = course_from_name(new_curriculum, new_course_name)
+    course = course_from_name(new_course_name, new_curriculum)
     my_centrality_paths = centrality_investigator(course, new_curriculum)
     if length(my_centrality_paths) > 0
         # ok actually do stuff
@@ -183,7 +183,7 @@ function add_course_institutional!(curriculum::Curriculum, course_name::Abstract
     # get all the paths that depend on me
     ## first, get me
     #UCSD = read_csv("./targets/condensed.csv");
-    course = course_from_name(new_curriculum, new_course_name)
+    course = course_from_name(new_course_name, new_curriculum)
     my_centrality_paths = centrality_investigator(course, new_curriculum)
     if length(my_centrality_paths) > 0
         # ok actually do stuff
@@ -236,7 +236,7 @@ function add_course_institutional!(curriculum::Curriculum, course_name::Abstract
 end
 
 function add_prereq_institutional(curriculum::Curriculum, course_with_new_prereq::AbstractString, prereq::AbstractString)
-    course_with_new_prereq = course_from_name(curriculum, course_with_new_prereq)
+    course_with_new_prereq = course_from_name(course_with_new_prereq, curriculum)
     if typeof(course_with_new_prereq) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your target course in the given curriculum. Make sure you got the name exactly right."))
     end
@@ -250,7 +250,7 @@ function add_prereq_institutional(curriculum::Curriculum, course_with_new_prereq
 end
 
 function add_prereq_institutional!(curriculum::Curriculum, course_with_new_prereq::AbstractString, prereq::AbstractString)
-    course_with_new_prereq_course = course_from_name(curriculum, course_with_new_prereq)
+    course_with_new_prereq_course = course_from_name(course_with_new_prereq, curriculum)
     if typeof(course_with_new_prereq) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your target course in the given curriculum. Make sure you got the name exactly right."))
     end

--- a/src/WhatifInstitutional.jl
+++ b/src/WhatifInstitutional.jl
@@ -1,4 +1,4 @@
-function delete_prerequisite_institutional(curriculum::Curriculum, target::AbstractString, prereq::AbstractString)
+function delete_prerequisite_institutional(target::AbstractString, prereq::AbstractString, curriculum::Curriculum)
     target_course = course_from_name(target, curriculum)
     # error check
     if typeof(target_course) == Nothing
@@ -28,7 +28,7 @@ function delete_prerequisite_institutional(curriculum::Curriculum, target::Abstr
     return ret
 end
 
-function delete_prerequisite_institutional!(curriculum::Curriculum, target::AbstractString, prereq::AbstractString)
+function delete_prerequisite_institutional!(target::AbstractString, prereq::AbstractString, curriculum::Curriculum)
     target_course = course_from_name(target, curriculum)
     # error check
     if typeof(target_course) == Nothing
@@ -56,7 +56,7 @@ function delete_prerequisite_institutional!(curriculum::Curriculum, target::Abst
     return ret
 end
 
-function delete_course_institutional(curriculum::Curriculum, course_to_remove_name::AbstractString)
+function delete_course_institutional(course_to_remove_name::AbstractString, curriculum::Curriculum)
     course_to_remove = course_from_name(course_to_remove_name, curriculum)
     if typeof(course_to_remove) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your target course in the given curriculum. Make sure you got the name exactly right."))
@@ -97,7 +97,7 @@ function delete_course_institutional(curriculum::Curriculum, course_to_remove_na
     end
 end
 
-function delete_course_institutional!(curriculum::Curriculum, course_to_remove_name::AbstractString)
+function delete_course_institutional!(course_to_remove_name::AbstractString, curriculum::Curriculum)
     course_to_remove = course_from_name(course_to_remove_name, curriculum)
     if typeof(course_to_remove) == Nothing
         throw(ArgumentError("I'm sorry, we couldn't find your target course in the given curriculum. Make sure you got the name exactly right."))
@@ -114,7 +114,7 @@ function delete_course_institutional!(curriculum::Curriculum, course_to_remove_n
 end
 
 
-function add_course_institutional(curriculum::Curriculum, new_course_name::AbstractString, new_course_credit_hours::Real, prereqs::Dict, dependencies::Dict)
+function add_course_institutional(new_course_name::AbstractString, curriculum::Curriculum, new_course_credit_hours::Real, prereqs::Dict, dependencies::Dict)
     new_curriculum = add_course(curriculum, new_course_name, new_course_credit_hours, prereqs, dependencies)
     # TODO error checking on this one
     errors = IOBuffer()
@@ -175,7 +175,7 @@ function add_course_institutional(curriculum::Curriculum, new_course_name::Abstr
 end
 
 # TODO: edit to add the 
-function add_course_institutional!(curriculum::Curriculum, course_name::AbstractString, new_course_credit_hours::Real, prereqs::Dict, dependencies::Dict)
+function add_course_institutional!(course_name::AbstractString, curriculum::Curriculum, new_course_credit_hours::Real, prereqs::Dict, dependencies::Dict)
     new_curriculum = add_course(curriculum, course_name, new_course_credit_hours, prereqs, dependencies)
     # TODO error checking on this one
     errors = IOBuffer()

--- a/test/HelperFnsTests.jl
+++ b/test/HelperFnsTests.jl
@@ -5,9 +5,9 @@ using Test
 @testset "HelperFns tests.jl" begin
     test = read_csv("./files/SY-Curriculum Plan-BE25.csv")
     # course from name
-    @test course_from_name(test, "MATH 20A") === test.courses[2]
-    @test course_from_name(test, "PHYS 2A") === test.courses[5]
-    @test typeof(course_from_name(test, "BENG 130")) == Course
+    @test course_from_name("MATH 20A", test) === test.courses[2]
+    @test course_from_name("PHYS 2A", test) === test.courses[5]
+    @test typeof(course_from_name("BENG 130", test)) == Course
 
     # get course prereqs
     @test get_course_prereqs(test.courses[2], test) == Vector{Course}()
@@ -27,12 +27,12 @@ using Test
     # longest path to me
     @test typeof(longest_path_to_me(test.courses[11], test, test.courses[11], false)) == Vector{Course}
     @test longest_path_to_me(test.courses[11], test, test.courses[11], false) == [test.courses[2], test.courses[4], test.courses[7], test.courses[11]]
-    @test longest_path_to_me(course_from_name(test, "BENG 110"), test, test.courses[24], false) == [course_from_name(test, "MATH 20A"), course_from_name(test, "MATH 20B"), course_from_name(test, "MATH 20C"), course_from_name(test, "MATH 20D"), course_from_name(test, "BENG 110")]
+    @test longest_path_to_me(course_from_name("BENG 110", test), test, test.courses[24], false) == [course_from_name("MATH 20A", test), course_from_name("MATH 20B", test), course_from_name("MATH 20C", test), course_from_name("MATH 20D", test), course_from_name("BENG 110", test)]
     # canonical longest path through to phys 2b is math 20a phys 2a phys2b
-    @test longest_path_to_me(course_from_name(test, "PHYS 2B"), test, test.courses[8], false) == [test.courses[2], test.courses[5], test.courses[8]]
+    @test longest_path_to_me(course_from_name("PHYS 2B", test), test, test.courses[8], false) == [test.courses[2], test.courses[5], test.courses[8]]
     # alt longest path through to phys2b is math20a, math20b, phys 2b. This should return math20b, phys 2b
-    @test longest_path_to_me(course_from_name(test, "PHYS 2B"), test, test.courses[4], true) == [test.courses[4], test.courses[8]]
-    @test longest_path_to_me(course_from_name(test, "PHYS 2B"), test, test.courses[9], true) == [course_from_name(test, "PHYS 2B")]
+    @test longest_path_to_me(course_from_name("PHYS 2B", test), test, test.courses[4], true) == [test.courses[4], test.courses[8]]
+    @test longest_path_to_me(course_from_name("PHYS 2B", test), test, test.courses[9], true) == [course_from_name("PHYS 2B", test)]
 
     # course to course names
     @test typeof(courses_to_course_names([test.courses[11], test.courses[12], test.courses[15], test.courses[18]])) == Vector{AbstractString}

--- a/test/HelperFnsTests.jl
+++ b/test/HelperFnsTests.jl
@@ -10,13 +10,13 @@ using Test
     @test typeof(course_from_name(test, "BENG 130")) == Course
 
     # get course prereqs
-    @test get_course_prereqs(test, test.courses[2]) == Vector{Course}()
-    @test get_course_prereqs(test, test.courses[5]) == Vector{Course}([test.courses[2]])
-    @test typeof(get_course_prereqs(test, test.courses[5])) == Vector{Course}
-    @test get_course_prereqs(test, test.courses[22]) == Vector{Course}([test.courses[6], test.courses[15], test.courses[7]])
-    @test get_course_prereqs(test, test.courses[26]) == Vector{Course}([test.courses[5], test.courses[4], test.courses[2], test.courses[11], test.courses[8], test.courses[14], test.courses[3]])
-    @test get_course_prereqs(test, test.courses[26]) != Vector{Course}([test.courses[4], test.courses[5], test.courses[11], test.courses[8], test.courses[14], test.courses[2], test.courses[3]])
-    @test Set(get_course_prereqs(test, test.courses[26])) == Set(Vector{Course}([test.courses[4], test.courses[5], test.courses[11], test.courses[8], test.courses[14], test.courses[2], test.courses[3]]))
+    @test get_course_prereqs(test.courses[2], test) == Vector{Course}()
+    @test get_course_prereqs(test.courses[5], test) == Vector{Course}([test.courses[2]])
+    @test typeof(get_course_prereqs(test.courses[5], test)) == Vector{Course}
+    @test get_course_prereqs(test.courses[22], test) == Vector{Course}([test.courses[6], test.courses[15], test.courses[7]])
+    @test get_course_prereqs(test.courses[26], test) == Vector{Course}([test.courses[5], test.courses[4], test.courses[2], test.courses[11], test.courses[8], test.courses[14], test.courses[3]])
+    @test get_course_prereqs(test.courses[26], test) != Vector{Course}([test.courses[4], test.courses[5], test.courses[11], test.courses[8], test.courses[14], test.courses[2], test.courses[3]])
+    @test Set(get_course_prereqs(test.courses[26], test)) == Set(Vector{Course}([test.courses[4], test.courses[5], test.courses[11], test.courses[8], test.courses[14], test.courses[2], test.courses[3]]))
 
     # courses that depend on me (first level only)
     @test typeof(courses_that_depend_on_me(test.courses[10], test)) == Vector{Course}


### PR DESCRIPTION
This should change most if not all function signatures to be consistently what1, what 2,...,where. Previously, some used curriculum then course in the function signature. Now it's all course, curriculum. Do note that "what" is usually restricted to the course name. Extra details come after the what and the where